### PR TITLE
address aiohttp3 warnings

### DIFF
--- a/bouncerscript/test/__init__.py
+++ b/bouncerscript/test/__init__.py
@@ -54,7 +54,7 @@ def fake_ClientError_throwing_session(event_loop):
     def _fake_request(method, url, *args, **kwargs):
         raise aiohttp.ClientError
 
-    session = aiohttp.ClientSession()
+    session = aiohttp.ClientSession(loop=event_loop)
     session._request = _fake_request
     return session
 
@@ -65,7 +65,7 @@ def fake_TimeoutError_throwing_session(event_loop):
     def _fake_request(method, url, *args, **kwargs):
         raise aiohttp.ServerTimeoutError
 
-    session = aiohttp.ClientSession()
+    session = aiohttp.ClientSession(loop=event_loop)
     session._request = _fake_request
     return session
 

--- a/bouncerscript/test/test_utils.py
+++ b/bouncerscript/test/test_utils.py
@@ -78,7 +78,6 @@ def test_do_successful_api_call(context, mocker, event_loop, fake_session, data,
     )
 
     assert response == '{}'
-    context.session.close()
 
 
 # _do_api_call {{{1
@@ -92,7 +91,6 @@ def test_do_failed_api_call(context, mocker, event_loop, fake_session_500):
     )
 
     assert response == '{}'
-    context.session.close()
 
 
 # _do_api_call {{{1
@@ -106,8 +104,6 @@ def test_do_failed_with_ClientError_api_call(context, mocker, event_loop, fake_C
             _do_api_call(context, 'dummy', {})
         )
 
-    context.session.close()
-
 
 # _do_api_call {{{1
 def test_do_failed_with_TimeoutError_api_call(context, mocker, event_loop, fake_TimeoutError_throwing_session):
@@ -119,8 +115,6 @@ def test_do_failed_with_TimeoutError_api_call(context, mocker, event_loop, fake_
         event_loop.run_until_complete(
             _do_api_call(context, 'dummy', {})
         )
-
-    context.session.close()
 
 
 # does_product_exists {{{1


### PR DESCRIPTION
This should probably land after
https://github.com/mozilla-releng/scriptworker/pull/200 , and doesn't
block aiohttp3 rollout.