### PR TITLE
stop using scriptworker event_loop fixture

### DIFF
--- a/bouncerscript/test/__init__.py
+++ b/bouncerscript/test/__init__.py
@@ -4,10 +4,6 @@ import json
 import pytest
 
 from scriptworker.context import Context
-from scriptworker.test import event_loop
-
-
-assert event_loop  # silence flake8
 
 
 def noop_sync(*args, **kwargs):
@@ -49,23 +45,25 @@ def aliases_context():
 
 
 @pytest.fixture(scope='function')
-def fake_ClientError_throwing_session(event_loop):
+def fake_ClientError_throwing_session():
     @asyncio.coroutine
     def _fake_request(method, url, *args, **kwargs):
         raise aiohttp.ClientError
 
-    session = aiohttp.ClientSession(loop=event_loop)
+    loop = asyncio.get_event_loop()
+    session = aiohttp.ClientSession(loop=loop)
     session._request = _fake_request
     return session
 
 
 @pytest.fixture(scope='function')
-def fake_TimeoutError_throwing_session(event_loop):
+def fake_TimeoutError_throwing_session():
     @asyncio.coroutine
     def _fake_request(method, url, *args, **kwargs):
         raise aiohttp.ServerTimeoutError
 
-    session = aiohttp.ClientSession(loop=event_loop)
+    loop = asyncio.get_event_loop()
+    session = aiohttp.ClientSession(loop=loop)
     session._request = _fake_request
     return session
 

--- a/bouncerscript/test/test_script.py
+++ b/bouncerscript/test/test_script.py
@@ -9,20 +9,20 @@ from bouncerscript.test import (
     submission_context, noop_async, aliases_context, return_true
 )
 from scriptworker.test import (
-    event_loop, fake_session,
+    fake_session,
 )
 from scriptworker.exceptions import (
     ScriptWorkerTaskException, TaskVerificationError
 )
 
 
-assert event_loop, fake_session  # silence flake8
+assert fake_session  # silence flake8
 assert submission_context  # silence flake8
 assert aliases_context  # silence flake8
 
 
 # main {{{1
-def test_main(submission_context, event_loop, fake_session):
+def test_main(submission_context, fake_session):
     async def fake_async_main_with_exception(context):
         raise ScriptWorkerTaskException("This is wrong, the answer is 42")
 
@@ -57,7 +57,7 @@ async def test_bouncer_aliases(aliases_context, mocker):
 
 # async_main {{{1
 @pytest.mark.asyncio
-async def test_async_main(submission_context, mocker, event_loop):
+async def test_async_main(submission_context, mocker):
     mocker.patch.object(bscript, 'bouncer_submission', new=noop_async)
     mocker.patch.object(bscript, 'does_product_exists', new=noop_async)
     mocker.patch.object(bscript, 'api_add_product', new=noop_async)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 scriptworker
-aiohttp==3.2.1


### PR DESCRIPTION
This fixture is being removed in mozilla-releng/scriptworker#241 ; let's stop
using it.