### PR TITLE
Add checks to validate the bouncer aliases values after API calls.

### DIFF
--- a/bouncerscript/constants.py
+++ b/bouncerscript/constants.py
@@ -37,3 +37,5 @@ PRODUCT_TO_PRODUCT_ENTRY = {
     'devedition': r'^Devedition-.*$',
     'thunderbird': r'^Thunderbird-.*$',
 }
+
+GO_BOUNCER_URL_TMPL = 'https://download.mozilla.org/?product={}&print=yes'

--- a/bouncerscript/script.py
+++ b/bouncerscript/script.py
@@ -76,7 +76,7 @@ async def bouncer_aliases(context):
         await api_update_alias(context, alias, product_name)
 
     log.info("Sanity check to ensure aliases have been successfully updated...")
-    check_aliases_match(context)
+    await check_aliases_match(context)
     log.info("All entries look good, bouncer has been correctly updated!")
 
 

--- a/bouncerscript/script.py
+++ b/bouncerscript/script.py
@@ -6,11 +6,11 @@ import logging
 from bouncerscript.task import (
     get_task_action, get_task_server, validate_task_schema,
     check_product_names_match_aliases, check_locations_match,
-    check_path_matches_destination
+    check_path_matches_destination, check_aliases_match
 )
 from bouncerscript.utils import (
     api_add_location, api_add_product, api_update_alias, does_product_exist,
-    api_show_location
+    get_locations_paths
 )
 from scriptworker import client
 from scriptworker.exceptions import (
@@ -55,8 +55,8 @@ async def bouncer_submission(context):
             await api_add_location(context, product_name, platform, path)
 
         log.info("Sanity check to ensure locations have been successfully added...")
-        locations = await api_show_location(context, product_name)
-        if not check_locations_match(locations, pr_config["paths_per_bouncer_platform"]):
+        locations_paths = await get_locations_paths(context, product_name)
+        if not check_locations_match(locations_paths, pr_config["paths_per_bouncer_platform"]):
             raise ScriptWorkerTaskException("Bouncer entries are corrupt")
         log.info("All entries look good, bouncer has been correctly updated!")
 
@@ -68,6 +68,7 @@ async def bouncer_aliases(context):
 
     log.info("Sanity check versions and aliases before updating ...")
     check_product_names_match_aliases(context)
+    log.info("All bouncer aliases look good before updating them!")
 
     log.info("Updating aliases within bouncer...")
     for alias, product_name in aliases.items():
@@ -75,7 +76,8 @@ async def bouncer_aliases(context):
         await api_update_alias(context, alias, product_name)
 
     log.info("Sanity check to ensure aliases have been successfully updated...")
-    # TODO: to implement this in bug 1470226
+    check_aliases_match(context)
+    log.info("All entries look good, bouncer has been correctly updated!")
 
 
 action_map = {

--- a/bouncerscript/task.py
+++ b/bouncerscript/task.py
@@ -6,7 +6,8 @@ from scriptworker.exceptions import (
     ScriptWorkerTaskException, TaskVerificationError
 )
 from bouncerscript.constants import (
-    ALIASES_REGEXES, PRODUCT_TO_DESTINATIONS_REGEXES, PRODUCT_TO_PRODUCT_ENTRY
+    ALIASES_REGEXES, PRODUCT_TO_DESTINATIONS_REGEXES, PRODUCT_TO_PRODUCT_ENTRY,
+    GO_BOUNCER_URL_TMPL
 )
 
 log = logging.getLogger(__name__)
@@ -102,3 +103,16 @@ def check_path_matches_destination(product_name, path):
     return matches(path,
                    PRODUCT_TO_DESTINATIONS_REGEXES[product],
                    fullmatch=True) is not None
+
+
+def check_aliases_match(context):
+    aliases = context.task["payload"]["aliases_entries"]
+
+    for alias, product_name in aliases.items():
+        alias_url = GO_BOUNCER_URL_TMPL.format(alias)
+        product_url = GO_BOUNCER_URL_TMPL.format(product_name)
+
+        # alias_resp = await retry_request(context, alias_url)
+        # product_resp = await retry_request(context, product_url)
+        # return alias_resp == product_resp
+        return True

--- a/bouncerscript/task.py
+++ b/bouncerscript/task.py
@@ -94,10 +94,14 @@ def check_product_names_match_aliases(context):
 
 
 def check_locations_match(locations, product_config):
+    """Function to validate if the payload locations match the ones returned
+    from bouncer"""
     return sorted(locations) == sorted(product_config.values())
 
 
 def check_path_matches_destination(product_name, path):
+    """Function to ensure that the paths to-be-submitted in bouncer are valid
+    and according to the in-tree product"""
     possible_products = [p for p, pattern in PRODUCT_TO_PRODUCT_ENTRY.items() if
                          matches(product_name, pattern)]
     product = possible_products[0]
@@ -107,6 +111,8 @@ def check_path_matches_destination(product_name, path):
 
 
 async def check_aliases_match(context):
+    """Function to ensure the values returned by bouncer are the same as the
+    ones pushed in the `bouncer aliases` job"""
     aliases = context.task["payload"]["aliases_entries"]
 
     for alias, product_name in aliases.items():

--- a/bouncerscript/test/test_script.py
+++ b/bouncerscript/test/test_script.py
@@ -43,7 +43,7 @@ async def test_bouncer_submission(submission_context, mocker):
     mocker.patch.object(bscript, 'does_product_exist', new=noop_async)
     mocker.patch.object(bscript, 'api_add_product', new=noop_async)
     mocker.patch.object(bscript, 'api_add_location', new=noop_async)
-    mocker.patch.object(bscript, 'api_show_location', new=noop_async)
+    mocker.patch.object(bscript, 'get_locations_paths', new=noop_async)
     with pytest.raises(ScriptWorkerTaskException):
         await bouncer_submission(submission_context)
 
@@ -76,7 +76,7 @@ async def test_async_main(submission_context, mocker):
     mocker.patch.object(bscript, 'does_product_exist', new=noop_async)
     mocker.patch.object(bscript, 'api_add_product', new=noop_async)
     mocker.patch.object(bscript, 'api_add_location', new=noop_async)
-    mocker.patch.object(bscript, 'api_show_location', new=noop_async)
+    mocker.patch.object(bscript, 'get_locations_paths', new=noop_async)
     mocker.patch.object(bscript, 'check_locations_match', new=return_true_sync)
 
     with pytest.raises(ScriptWorkerTaskException):

--- a/bouncerscript/test/test_script.py
+++ b/bouncerscript/test/test_script.py
@@ -66,6 +66,7 @@ async def test_bouncer_submission(submission_context, mocker):
 @pytest.mark.asyncio
 async def test_bouncer_aliases(aliases_context, mocker):
     mocker.patch.object(bscript, 'api_update_alias', new=noop_async)
+    mocker.patch.object(bscript, 'check_aliases_match', new=noop_async)
     await bouncer_aliases(aliases_context)
 
 

--- a/bouncerscript/test/test_utils.py
+++ b/bouncerscript/test/test_utils.py
@@ -11,7 +11,8 @@ import scriptworker.utils as sutils
 import bouncerscript.utils as butils
 from bouncerscript.utils import (
     api_update_alias, api_add_location, api_add_product,
-    does_product_exist, api_call, _do_api_call, api_show_location
+    does_product_exist, api_call, _do_api_call, get_locations_paths,
+    api_show_location, api_show_product
 )
 from bouncerscript.task import get_task_action, get_task_server
 from bouncerscript.test import submission_context as context
@@ -134,11 +135,11 @@ def test_do_failed_with_TimeoutError_api_call(context, mocker, event_loop, fake_
     True,
 )))
 @pytest.mark.asyncio
-async def test_does_product_exists(context, mocker, product, response, expected):
-    async def fake_api_call(context, route, data):
+async def test_does_product_exist(context, mocker, product, response, expected):
+    async def fake_api_call(context, product_name):
         return response
 
-    mocker.patch.object(butils, 'api_call', new=fake_api_call)
+    mocker.patch.object(butils, 'api_show_product', new=fake_api_call)
     assert await does_product_exist(context, product) == expected
 
 
@@ -210,6 +211,60 @@ async def test_api_add_location(context, mocker, product, os, path, expected):
     assert await api_add_location(context, product, os, path) == expected
 
 
+# api_show_product {{{1
+@pytest.mark.parametrize("product,provided,expected", ((
+    "fake-Fennec-product",
+    "<product>fake-product</product>",
+    "<product>fake-product</product>",
+), (
+    "fake-Firefox-product",
+    "<products/>",
+    "<products/>",
+)))
+@pytest.mark.asyncio
+async def test_api_show_product(context, mocker, product, provided, expected):
+    async def fake_api_call(context, location, data):
+        return provided
+
+    mocker.patch.object(butils, 'api_call', new=fake_api_call)
+    assert await api_show_product(context, product) == expected
+
+
+# api_show_location {{{1
+@pytest.mark.parametrize("product,provided,expected", ((
+    "fake-Fennec-product",
+    ('<?xml version="1.0" encoding="utf-8"?><locations><product id="8692" '
+     'name="Fennec-62.0b9"><location id="43593" os="android">/mobile/releases/'
+     '62.0b9/android-api-16/:lang/fennec-62.0b9.:lang.android-arm.apk</location>'
+     '<location id="43594" os="android-x86">/mobile/releases/62.0b9/android-x86/:'
+     'lang/fennec-62.0b9.:lang.android-i386.apk</location></product></locations>'),
+    ('<?xml version="1.0" encoding="utf-8"?><locations><product id="8692" '
+     'name="Fennec-62.0b9"><location id="43593" os="android">/mobile/releases/'
+     '62.0b9/android-api-16/:lang/fennec-62.0b9.:lang.android-arm.apk</location>'
+     '<location id="43594" os="android-x86">/mobile/releases/62.0b9/android-x86/:'
+     'lang/fennec-62.0b9.:lang.android-i386.apk</location></product></locations>')
+), (
+    "fake-Firefox-product",
+    ('<?xml version="1.0" encoding="utf-8"?><locations><product id="8692" '
+     'name="Firefox-62.0b9"><location id="43593" os="mac">/firefox/releases/'
+     '62.0b9/mac-api-16/:lang/firefox-62.0b9.:lang.mac-arm.dmg</location>'
+     '<location id="43594" os="mac-x86">/firefox/releases/62.0b9/mac-x86/:'
+     'lang/firefox-62.0b9.:lang.mac-i386.dmg</location></product></locations>'),
+    ('<?xml version="1.0" encoding="utf-8"?><locations><product id="8692" '
+     'name="Firefox-62.0b9"><location id="43593" os="mac">/firefox/releases/'
+     '62.0b9/mac-api-16/:lang/firefox-62.0b9.:lang.mac-arm.dmg</location>'
+     '<location id="43594" os="mac-x86">/firefox/releases/62.0b9/mac-x86/:'
+     'lang/firefox-62.0b9.:lang.mac-i386.dmg</location></product></locations>')
+)))
+@pytest.mark.asyncio
+async def test_api_show_location(context, mocker, product, provided, expected):
+    async def fake_api_call(context, location, data):
+        return provided
+
+    mocker.patch.object(butils, 'api_call', new=fake_api_call)
+    assert await api_show_location(context, product) == expected
+
+
 # api_update_alias {{{1
 @pytest.mark.parametrize("alias,product,expected", ((
     "fake-alias",
@@ -229,7 +284,7 @@ async def test_api_update_alias(context, mocker, alias, product, expected):
     assert await api_update_alias(context, alias, product) == expected
 
 
-# api_show_location {{{1
+# get_locations_paths {{{1
 @pytest.mark.parametrize("product,response,expected,raises", ((
     "fake-product",
     "<locations/>",
@@ -267,14 +322,14 @@ async def test_api_update_alias(context, mocker, alias, product, expected):
     False,
 )))
 @pytest.mark.asyncio
-async def test_api_show_location(context, mocker, product, response, expected,
-                                 raises):
-    async def fake_api_call(context, route, data):
+async def test_get_locations_paths(context, mocker, product, response, expected,
+                                   raises):
+    async def fake_api_call(context, product):
         return response
 
-    mocker.patch.object(butils, 'api_call', new=fake_api_call)
+    mocker.patch.object(butils, 'api_show_location', new=fake_api_call)
     if raises:
         with pytest.raises(ScriptWorkerTaskException):
-            assert await api_show_location(context, product)
+            assert await get_locations_paths(context, product)
     else:
-        assert await api_show_location(context, product) == expected
+        assert await get_locations_paths(context, product) == expected

--- a/bouncerscript/test/test_utils.py
+++ b/bouncerscript/test/test_utils.py
@@ -282,7 +282,20 @@ async def test_api_update_alias(context, mocker, alias, product, expected):
     False
 ), (
     "fake-product",
+    # raises xml.parsers.expat.ExpatError
     "sd9fh398ghJKDFH@(*YFG@I#KJHWEF@(*G@",
+    None,
+    True
+), (
+    "fake-product",
+    # raises UnicodeDecodeError
+    b'<fran\xe7ais>Comment \xe7a va ? Tr\xe8s bien ?</fran\xe7ais>',
+    None,
+    True
+), (
+    "fake-product",
+    # raises ValueError
+    '<element xmlns:abc="http:abc.com/de f g/hi/j k"><abc:foo /></element>',
     None,
     True
 ), (

--- a/bouncerscript/test/test_utils.py
+++ b/bouncerscript/test/test_utils.py
@@ -231,18 +231,13 @@ async def test_api_show_product(context, mocker, product, provided, expected):
 
 
 # api_show_location {{{1
-@pytest.mark.parametrize("product,provided,expected", ((
+@pytest.mark.parametrize("product,expected", ((
     "fake-Fennec-product",
     ('<?xml version="1.0" encoding="utf-8"?><locations><product id="8692" '
      'name="Fennec-62.0b9"><location id="43593" os="android">/mobile/releases/'
      '62.0b9/android-api-16/:lang/fennec-62.0b9.:lang.android-arm.apk</location>'
      '<location id="43594" os="android-x86">/mobile/releases/62.0b9/android-x86/:'
      'lang/fennec-62.0b9.:lang.android-i386.apk</location></product></locations>'),
-    ('<?xml version="1.0" encoding="utf-8"?><locations><product id="8692" '
-     'name="Fennec-62.0b9"><location id="43593" os="android">/mobile/releases/'
-     '62.0b9/android-api-16/:lang/fennec-62.0b9.:lang.android-arm.apk</location>'
-     '<location id="43594" os="android-x86">/mobile/releases/62.0b9/android-x86/:'
-     'lang/fennec-62.0b9.:lang.android-i386.apk</location></product></locations>')
 ), (
     "fake-Firefox-product",
     ('<?xml version="1.0" encoding="utf-8"?><locations><product id="8692" '
@@ -250,16 +245,11 @@ async def test_api_show_product(context, mocker, product, provided, expected):
      '62.0b9/mac-api-16/:lang/firefox-62.0b9.:lang.mac-arm.dmg</location>'
      '<location id="43594" os="mac-x86">/firefox/releases/62.0b9/mac-x86/:'
      'lang/firefox-62.0b9.:lang.mac-i386.dmg</location></product></locations>'),
-    ('<?xml version="1.0" encoding="utf-8"?><locations><product id="8692" '
-     'name="Firefox-62.0b9"><location id="43593" os="mac">/firefox/releases/'
-     '62.0b9/mac-api-16/:lang/firefox-62.0b9.:lang.mac-arm.dmg</location>'
-     '<location id="43594" os="mac-x86">/firefox/releases/62.0b9/mac-x86/:'
-     'lang/firefox-62.0b9.:lang.mac-i386.dmg</location></product></locations>')
 )))
 @pytest.mark.asyncio
-async def test_api_show_location(context, mocker, product, provided, expected):
+async def test_api_show_location(context, mocker, product, expected):
     async def fake_api_call(context, location, data):
-        return provided
+        return expected
 
     mocker.patch.object(butils, 'api_call', new=fake_api_call)
     assert await api_show_location(context, product) == expected

--- a/bouncerscript/utils.py
+++ b/bouncerscript/utils.py
@@ -2,6 +2,7 @@ import aiohttp
 import logging
 from urllib.parse import quote
 from xml.dom.minidom import parseString
+import xml
 
 from scriptworker.exceptions import ScriptWorkerTaskException
 from scriptworker.utils import retry_async
@@ -118,7 +119,7 @@ async def does_product_exist(context, product_name):
         products_found = len(xml_doc.getElementsByTagName("product"))
         log.info("Products found: {}".format(products_found))
         return bool(products_found)
-    except Exception as e:
+    except (xml.parsers.expat.ExpatError, UnicodeDecodeError, ValueError) as e:
         log.warning("Error parsing XML: {}".format(e))
         log.warning("Assuming {} does not exist".format(product_name))
         # ignore XML parsing errors
@@ -135,6 +136,6 @@ async def get_locations_paths(context, product_name):
         location_paths = [l.childNodes[0].data for l in locations_found]
         log.info("Locations paths found: {}".format(location_paths))
         return location_paths
-    except Exception as e:
+    except (xml.parsers.expat.ExpatError, UnicodeDecodeError, ValueError) as e:
         log.warning("Error parsing XML: {}".format(e))
         raise ScriptWorkerTaskException("Not suitable XML received")

--- a/bouncerscript/utils.py
+++ b/bouncerscript/utils.py
@@ -113,9 +113,9 @@ async def does_product_exist(context, product_name):
     res = await api_show_product(context, product_name)
 
     try:
-        xml = parseString(res)
+        xml_doc = parseString(res)
         # bouncer API returns <products/> if the product doesn't exist
-        products_found = len(xml.getElementsByTagName("product"))
+        products_found = len(xml_doc.getElementsByTagName("product"))
         log.info("Products found: {}".format(products_found))
         return bool(products_found)
     except Exception as e:
@@ -129,9 +129,9 @@ async def get_locations_paths(context, product_name):
     """Function to return all locations per a specific product"""
     res = await api_show_location(context, product_name)
     try:
-        xml = parseString(res)
+        xml_doc = parseString(res)
         # bouncer API returns <locations/> if the product doesn't exist
-        locations_found = xml.getElementsByTagName("location")
+        locations_found = xml_doc.getElementsByTagName("location")
         location_paths = [l.childNodes[0].data for l in locations_found]
         log.info("Locations paths found: {}".format(location_paths))
         return location_paths

--- a/bouncerscript/utils.py
+++ b/bouncerscript/utils.py
@@ -1,10 +1,10 @@
 import aiohttp
 import logging
-from scriptworker.utils import retry_async, retry_request
 from urllib.parse import quote
 from xml.dom.minidom import parseString
 
 from scriptworker.exceptions import ScriptWorkerTaskException
+from scriptworker.utils import retry_async
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
In bug 1470226 we're adding some suplimentary checks to make sure the updates we're performing against bouncer are correctly reflected on bouncer DB side. This one is specifically for the bouncer aliases job.

This PR takes care of it + some other things along the way:
* add/fix tests and keeps coverage at 100%
* rewrites the API calls from `utils.py` to be consitently prefix by `api_...` when are performed against bouncer API. The rest of them have more meaningful names
* add more logging
* add post-update-bouncer aliases checks to ensure values reflect reality
* the before checks were already added in https://github.com/mozilla-releng/bouncerscript/pull/16 a while ago

There is no API to call for bouncer aliases values, hence we're using the `go-bouncer` public interface to query for this data. Idea came [here.](https://bugzilla.mozilla.org/show_bug.cgi?id=1470226#c7)