### PR TITLE
Fix flake8 issues with newest package

### DIFF
--- a/bouncerscript/constants.py
+++ b/bouncerscript/constants.py
@@ -1,46 +1,46 @@
 ALIASES_REGEXES = {
-    'thunderbird-beta-latest': '^Thunderbird-\d+\.0b\d+$',
-    'thunderbird-beta-latest-ssl': '^Thunderbird-\d+\.0b\d+-SSL$',
-    'thunderbird-next-latest': '^Thunderbird-\d+\.\d+(\.\d+)?$',
-    'thunderbird-next-latest-ssl': '^Thunderbird-\d+\.\d+(\.\d+)?-SSL$',
-    'thunderbird-latest': '^Thunderbird-\d+\.\d+(\.\d+)?$',
-    'thunderbird-latest-ssl': '^Thunderbird-\d+\.\d+(\.\d+)?-SSL$',
-    'fennec-beta-latest': '^Fennec-\d+\.0b\d+$',
-    'fennec-latest': '^Fennec-\d+\.\d+(\.\d+)?$',
-    'firefox-devedition-stub': '^Devedition-\d+\.0b\d+-stub$',
-    'firefox-devedition-latest': '^Devedition-\d+\.0b\d+$',
-    'firefox-devedition-latest-ssl': '^Devedition-\d+\.0b\d+-SSL$',
-    'firefox-beta-stub': '^Firefox-\d+\.0b\d+-stub$',
-    'firefox-beta-latest': '^Firefox-\d+\.0b\d+$',
-    'firefox-beta-latest-ssl': '^Firefox-\d+\.0b\d+-SSL$',
-    'firefox-stub': '^Firefox-\d+\.\d+(\.\d+)?-stub$',
-    'firefox-latest': '^Firefox-\d+\.\d+(\.\d+)?$',
-    'firefox-latest-ssl': '^Firefox-\d+\.\d+(\.\d+)?-SSL$',
-    'firefox-esr-latest': '^Firefox-\d+\.\d+(\.\d+)?esr$',
-    'firefox-esr-latest-ssl': '^Firefox-\d+\.\d+(\.\d+)?esr-SSL$',
-    'firefox-esr-next-latest': '^Firefox-\d+\.\d+(\.\d+)?esr$',
-    'firefox-esr-next-latest-ssl': '^Firefox-\d+\.\d+(\.\d+)?esr-SSL$',
-    'firefox-sha1': '^Firefox-\d+\.\d+(\.\d+)?esr-sha1$',
-    'firefox-sha1-ssl': '^Firefox-\d+\.\d+(\.\d+)?esr-sha1$',
+    'thunderbird-beta-latest': r'^Thunderbird-\d+\.0b\d+$',
+    'thunderbird-beta-latest-ssl': r'^Thunderbird-\d+\.0b\d+-SSL$',
+    'thunderbird-next-latest': r'^Thunderbird-\d+\.\d+(\.\d+)?$',
+    'thunderbird-next-latest-ssl': r'^Thunderbird-\d+\.\d+(\.\d+)?-SSL$',
+    'thunderbird-latest': r'^Thunderbird-\d+\.\d+(\.\d+)?$',
+    'thunderbird-latest-ssl': r'^Thunderbird-\d+\.\d+(\.\d+)?-SSL$',
+    'fennec-beta-latest': r'^Fennec-\d+\.0b\d+$',
+    'fennec-latest': r'^Fennec-\d+\.\d+(\.\d+)?$',
+    'firefox-devedition-stub': r'^Devedition-\d+\.0b\d+-stub$',
+    'firefox-devedition-latest': r'^Devedition-\d+\.0b\d+$',
+    'firefox-devedition-latest-ssl': r'^Devedition-\d+\.0b\d+-SSL$',
+    'firefox-beta-stub': r'^Firefox-\d+\.0b\d+-stub$',
+    'firefox-beta-latest': r'^Firefox-\d+\.0b\d+$',
+    'firefox-beta-latest-ssl': r'^Firefox-\d+\.0b\d+-SSL$',
+    'firefox-stub': r'^Firefox-\d+\.\d+(\.\d+)?-stub$',
+    'firefox-latest': r'^Firefox-\d+\.\d+(\.\d+)?$',
+    'firefox-latest-ssl': r'^Firefox-\d+\.\d+(\.\d+)?-SSL$',
+    'firefox-esr-latest': r'^Firefox-\d+\.\d+(\.\d+)?esr$',
+    'firefox-esr-latest-ssl': r'^Firefox-\d+\.\d+(\.\d+)?esr-SSL$',
+    'firefox-esr-next-latest': r'^Firefox-\d+\.\d+(\.\d+)?esr$',
+    'firefox-esr-next-latest-ssl': r'^Firefox-\d+\.\d+(\.\d+)?esr-SSL$',
+    'firefox-sha1': r'^Firefox-\d+\.\d+(\.\d+)?esr-sha1$',
+    'firefox-sha1-ssl': r'^Firefox-\d+\.\d+(\.\d+)?esr-sha1$',
 }
 
 PRODUCT_TO_DESTINATIONS_REGEXES = {
-    'fennec': '^(/mobile/releases/.*?/(?:android-api-16|android-x86)/\:lang/fennec-.*\:lang\.(?:android-arm|android-i386)\.apk)$',
-    'firefox-rc': '^(/firefox/candidates/.*?/build[0-9]+/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64)/\:lang/(?:firefox|Firefox).*\.(?:bz2|dmg|exe|mar))$',
-    'firefox': '^(/firefox/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64)/\:lang/(?:firefox|Firefox).*\.(?:bz2|dmg|exe|mar))$',
-    'devedition': '^(/devedition/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64)/\:lang/(?:firefox|Firefox).*\.(?:bz2|dmg|exe|mar))$',
-    'thunderbird': '^(/thunderbird/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64)/\:lang/(?:thunderbird|Thunderbird).*\.(?:bz2|dmg|exe|mar))$',
+    'fennec': r'^(/mobile/releases/.*?/(?:android-api-16|android-x86)/\:lang/fennec-.*\:lang\.(?:android-arm|android-i386)\.apk)$',
+    'firefox-rc': r'^(/firefox/candidates/.*?/build[0-9]+/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64)/\:lang/(?:firefox|Firefox).*\.(?:bz2|dmg|exe|mar))$',
+    'firefox': r'^(/firefox/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64)/\:lang/(?:firefox|Firefox).*\.(?:bz2|dmg|exe|mar))$',
+    'devedition': r'^(/devedition/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64)/\:lang/(?:firefox|Firefox).*\.(?:bz2|dmg|exe|mar))$',
+    'thunderbird': r'^(/thunderbird/releases/.*?/(update/)?(?:linux-i686|linux-x86_64|mac|win32|win64)/\:lang/(?:thunderbird|Thunderbird).*\.(?:bz2|dmg|exe|mar))$',
 }
 
 BOUNCER_PATH_REGEXES_PER_PRODUCT = {
-    'firefox-nightly-latest': ('^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\.'
-                               '(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe))$'),
-    'firefox-nightly-latest-ssl': ('^(/firefox/nightly/latest-mozilla-central/firefox-\d+\.0a1\.en-US\.'
-                                   '(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe))$'),
-    'firefox-nightly-latest-l10n': ('^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\.'
-                                    '(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe))$'),
-    'firefox-nightly-latest-l10n-ssl': ('^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\.'
-                                        '(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe))$'),
+    'firefox-nightly-latest': (r'^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\.'
+                               r'(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe))$'),
+    'firefox-nightly-latest-ssl': (r'^(/firefox/nightly/latest-mozilla-central/firefox-\d+\.0a1\.en-US\.'
+                                   r'(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe))$'),
+    'firefox-nightly-latest-l10n': (r'^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\.'
+                                    r'(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe))$'),
+    'firefox-nightly-latest-l10n-ssl': (r'^(/firefox/nightly/latest-mozilla-central-l10n/firefox-\d+\.0a1\.:lang\.'
+                                        r'(?:linux-i686\.tar\.bz2|linux-x86_64\.tar\.bz2|mac\.dmg|win32\.installer\.exe|win64\.installer\.exe))$'),
 }
 
 # XXX A list of tuple is used because we care about the order:
@@ -65,4 +65,4 @@ BOUNCER_LOCATION_PLATFORMS = [
 
 GO_BOUNCER_URL_TMPL = 'https://download.mozilla.org/?product={}&print=yes'
 
-NIGHTLY_VERSION_REGEX = '\d+\.0a1'
+NIGHTLY_VERSION_REGEX = r'\d+\.0a1'


### PR DESCRIPTION
I have to make some changes to bouncerscript for msi (it seems) and when running tests locally I got failures, in part because packages are not pinned in tox, but at the least let's fix up flake8 issues now